### PR TITLE
fixup! recovery_ui: Respect margin_height while drawing battery capacity status

### DIFF
--- a/recovery_ui/screen_ui.cpp
+++ b/recovery_ui/screen_ui.cpp
@@ -867,7 +867,7 @@ void ScreenRecoveryUI::draw_menu_and_text_buffer_locked(
 // Draws the battery capacity on the screen. Should only be called with updateMutex locked.
 void ScreenRecoveryUI::draw_battery_capacity_locked() {
   int x;
-  int y = margin_height_ + gr_get_height(default_logo_.get());
+  int y = margin_height_ + gr_get_height(default_logo.get());
   int icon_x, icon_y, icon_h, icon_w;
 
   // Battery status


### PR DESCRIPTION
* Why was there an underscore in the first place?